### PR TITLE
.travis.yml: Use build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: go
 
-env:
-  - GO15VENDOREXPERIMENT=1
-
 go:
-  #- tip
+  - tip
   - 1.6beta1
-  - 1.5.2
-  - 1.5.1
-  - 1.5
+
+matrix:
+  include:
+    - go: 1.5.2
+      env: GO15VENDOREXPERIMENT=1
+      # HINT: go-1.5.x needs GO15VENDOREXPERIMENT, therefore specify it via "include"
+  allow_failures:
+    - go: tip
+      # HINT: this is only for interest -- decision to support new versions is made manually


### PR DESCRIPTION
* Now we check the go `tip` version without failing builds
* Now only go-1.5.x uses GO15VENDOREXPERIMENT variable, because it's default in go-1.6